### PR TITLE
build: :wrench: 推移的依存パッケージをrequire出来るようにした

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern=*


### PR DESCRIPTION
vscodeのStorybook-Openerが動かなかったため。若干pnpmが遅くなることだけ問題。